### PR TITLE
ensure item void recipes use pre-existing icon sizes instead of changing it

### DIFF
--- a/prototypes/void-recipes/item-void.lua
+++ b/prototypes/void-recipes/item-void.lua
@@ -55,7 +55,7 @@ for _, type in pairs(groups) do
             if item.icons then
                 new_icons = table.deepcopy(item.icons)
             else
-                new_icons = {{icon = item.icon}}
+                new_icons = {{icon = item.icon, icon_size = item.icon_size or 32}}
             end
             new_icons[#new_icons + 1] = {icon = "__pyindustry__/graphics/icons/no.png"}
             make_void_recipe(name, new_icons, item.name)


### PR DESCRIPTION
The bulk item void recipe creator was ignoring existing icon sizes if there were any, which caused a crash bug with the bioluminescence mod. This PR fixes it on my end.

Also see: https://github.com/ReikaKalseki/Bioluminescence/pull/3