### PR TITLE
English locale update

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -3,141 +3,141 @@ py-industry=Industry Items
 
 [item-name]
 py-asphalt=Asphalt
-py-iron-oxide=Iron oxide Tile
-py-limestone=Limestone Tile
-py-coal-tile=Coal Tile
-py-iron=Iron Tile
-py-steel=Steel Tile
-py-aluminium=Aluminium Tile
-py-nexelit=Nexelit Tile
+py-iron-oxide=Iron oxide tile
+py-limestone=Limestone tile
+py-coal-tile=Coal tile
+py-iron=Iron tile
+py-steel=Steel tile
+py-aluminium=Aluminium tile
+py-nexelit=Nexelit tile
 
 [item-description]
 py-asphalt=Good for boots
 py-coal-tile=Dark and mysterious
 
 [entity-name]
-py-tank-1000=Tank 1000L
-py-tank-1500=Tank 1500L
-py-tank-3000=Tank 3000L
-py-tank-4000=Tank 4000L
-py-tank-5000=Tank 5000L
-py-tank-6500=Tank 6500L
-py-tank-7000=Tank 7000L
-py-tank-8000=Tank 8000L
+py-tank-1000=PyTank (1 kL)
+py-tank-1500=PyTank (1.5 kL)
+py-tank-3000=PyTank (3 kL)
+py-tank-4000=PyTank (4 kL)
+py-tank-5000=PyTank (5 kL)
+py-tank-6500=PyTank (6.5 kL)
+py-tank-7000=PyTank (7 kL)
+py-tank-8000=PyTank (8 kL)
 
-py-check-valve=Check Valve
-py-overflow-valve=Overflow Valve
-py-underflow-valve=Underflow Valve
+py-check-valve=Check valve
+py-overflow-valve=Overflow valve
+py-underflow-valve=Underflow valve
 
-niobium-pipe=Niobum pipe
-niobium-pipe-to-ground=Niobum underground pipe
+niobium-pipe=Niobium pipe
+niobium-pipe-to-ground=Niobium pipe to ground
 
-poorman-wood-fence=Poor wood fence
+poorman-wood-fence=Poor man's wooden fence
 wood-fence=Wooden fence
 concrete-wall=Concrete wall
 
-accumulator-mk01=Nexelit-powered Accumulator MK01
-accumulator-mk02=Nexelit-powered Accumulator MK02
-py-local-radar=Local Radar
+accumulator-mk01=Nexelit-powered accumulator Mk I
+accumulator-mk02=Nexelit-powered accumulator Mk II
+py-local-radar=Local radar
 megadar=Megadar
 py-burner=Burner
 py-sinkhole=Py-Sinkhole
 py-gas-vent=Py-GasVent
 
 py-warehouse-basic=Warehouse
-py-warehouse-passive-provider=Passive Provider Warehouse
-py-warehouse-storage=Storage Warehouse
-py-warehouse-active-provider=Active Provider Warehouse
-py-warehouse-requester=Requester Warehouse
-py-warehouse-buffer=Buffer Warehouse
+py-warehouse-passive-provider=Passive provider warehouse
+py-warehouse-storage=Storage warehouse
+py-warehouse-active-provider=Active provider warehouse
+py-warehouse-requester=Requester warehouse
+py-warehouse-buffer=Buffer warehouse
 
 py-storehouse-basic=Storehouse
-py-storehouse-passive-provider=Passive Provider Storehouse
-py-storehouse-storage=Storage Storehouse
-py-storehouse-active-provider=Active Provider Storehouse
-py-storehouse-requester=Requester Storehouse
-py-storehouse-buffer=Buffer Storehouse
+py-storehouse-passive-provider=Passive provider storehouse
+py-storehouse-storage=Storage storehouse
+py-storehouse-active-provider=Active provider storehouse
+py-storehouse-requester=Requester storehouse
+py-storehouse-buffer=Buffer storehouse
 
 py-shed-basic=Shed
-py-shed-passive-provider=Passive Provider Shed
-py-shed-storage=Storage Shed
-py-shed-active-provider=Active Provider Shed
-py-shed-requester=Requester Shed
-py-shed-buffer=Buffer Shed
+py-shed-passive-provider=Passive provider shed
+py-shed-storage=Storage shed
+py-shed-active-provider=Active provider shed
+py-shed-requester=Requester shed
+py-shed-buffer=Buffer shed
 
-py-construction-robot-01= Construction Pynobot MK01
-py-recharge-station-mk01= Recharging Station MK01
-py-logistic-robot-01=Cargo Pynobot MK01
-py-roboport-mk01= Py Roboport MK01
+py-construction-robot-01=Construction pynobot Mk I
+py-recharge-station-mk01=Recharging station Mk I
+py-logistic-robot-01=Cargo pynobot Mk I
+py-roboport-mk01=Py roboport Mk I
 
 [entity-description]
-py-tank-1000=Sometimes you dont want to store that much.
-py-tank-1500=Cheap low-capacity tank.
+py-tank-1000=Sometimes you don't want to store that much.
+py-tank-1500=Cheap, low-capacity tank.
 py-tank-4000=Medium capacity tank.
 py-tank-5000=Medium capacity tank.
 py-tank-6500=Good capacity tank.
 
-py-check-valve=Allows flow only in direction of arrow.
-py-overflow-valve=Allows flow when input is over 80% full.
-py-underflow-valve=Allows flow when output is under 80% full.
+py-check-valve=Allows flow only in the direction of the arrow.
+py-overflow-valve=Allows flow when input is over 80%.
+py-underflow-valve=Allows flow when output is under 80%.
 
 poorman-wood-fence=At least you have something.
 wood-fence=Made of pure wood.
 concrete-wall=Hard and breakable.
 
 accumulator-mk01=Nexelit-powered accumulator to store great amounts of energy.
-accumulator-mk02=Next stage into Nexelit-powered accumulators to store huge amounts of energy.
+accumulator-mk02=Next stage in Nexelit-powered accumulators to store huge amounts of energy.
 py-local-radar=Does not have long range scanning abilities.
 megadar=Large radar structure.
-py-burner=Final destination of whatever you dont want anymore. You can collect the ashes.
-py-sinkhole=You found a huge underground cave. why not dump your unwanted liquids there?
+py-burner=Final destination of whatever you no longer need. You can collect the ashes.
+py-sinkhole=You found a huge underground cave. Why not dump your unwanted liquids there?
 py-gas-vent=Dispose unwanted gases into the atmosphere.
 
 py-warehouse-basic=Stores many many items
-py-warehouse-passive-provider=Passive Provider Warehouse
-py-warehouse-storage=Storage Warehouse
-py-warehouse-active-provider=Active Provider Warehouse
-py-warehouse-requester=Requester Warehouse
-py-warehouse-buffer=Buffer Warehouse
+py-warehouse-passive-provider=Passive provider warehouse
+py-warehouse-storage=Storage warehouse
+py-warehouse-active-provider=Active provider warehouse
+py-warehouse-requester=Requester warehouse
+py-warehouse-buffer=Buffer warehouse
 
 py-storehouse-basic=Stores some items
-py-storehouse-passive-provider=Passive Provider Storehouse
-py-storehouse-storage=Storage Storehouse
-py-storehouse-active-provider=Active Provider Storehouse
-py-storehouse-requester=Requester Storehouse
-py-storehouse-buffer=Buffer Storehouse
+py-storehouse-passive-provider=Passive provider storehouse
+py-storehouse-storage=Storage storehouse
+py-storehouse-active-provider=Active provider storehouse
+py-storehouse-requester=Requester storehouse
+py-storehouse-buffer=Buffer storehouse
 
 py-shed-basic=Stores some items
-py-shed-passive-provider=Passive Provider Shed
-py-shed-storage=Storage Shed
-py-shed-active-provider=Active Provider Shed
-py-shed-requester=Requester Shed
-py-shed-buffer=Buffer Shed
+py-shed-passive-provider=Passive provider shed
+py-shed-storage=Storage shed
+py-shed-active-provider=Active provider shed
+py-shed-requester=Requester shed
+py-shed-buffer=Buffer shed
 
 [technology-name]
-py-storage-tanks=Storage Tanks
+py-storage-tanks=Storage tanks
 py-burner=Burner
 py-asphalt=Asphalt
 py-warehouse-research=Warehousing
-py-warehouse-logistics-research=Logistics Warehousing
+py-warehouse-logistics-research=Logistics warehousing
 
 [technology-description]
-py-storage-tanks=Add more types of storage tanks.
+py-storage-tanks=Adds more sizes of storage tanks.
 py-asphalt=Make new tiles.
-py-burner=Add Burner
+py-burner=Add burners.
 
 [tile-name]
 py-asphalt=Asphalt
-py-coal-tile=Coal Tile
-py-limestone=Limestone Tile
-py-iron-oxide=Iron oxide Tile
-py-iron=Iron Tile
-py-steel=Steel Tile
-py-aluminium=Aluminium Tile
-py-nexelit=Nexelit Tile
+py-coal-tile=Coal tile
+py-limestone=Limestone tile
+py-iron-oxide=Iron oxide tile
+py-iron=Iron tile
+py-steel=Steel tile
+py-aluminium=Aluminium tile
+py-nexelit=Nexelit tile
 
 [wall-name]
-poorman-wood-fence=Poor´s man wood fence
+poorman-wood-fence=Poor's man wood fence
 
 [mod-setting-name]
-py-tank-adjust=Adjust Pymods storage tanks capacity
+py-tank-adjust=Adjust Pymods' storage tanks capacity

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -36,8 +36,8 @@ poorman-wood-fence=Poor man's wooden fence
 wood-fence=Wooden fence
 concrete-wall=Concrete wall
 
-accumulator-mk01=Nexelit-powered accumulator MK 1
-accumulator-mk02=Nexelit-powered accumulator MK 2
+accumulator-mk01=Nexelit-powered accumulator MK 01
+accumulator-mk02=Nexelit-powered accumulator MK 02
 py-local-radar=Local radar
 megadar=Megadar
 py-burner=Burner
@@ -65,10 +65,10 @@ py-shed-active-provider=Active provider shed
 py-shed-requester=Requester shed
 py-shed-buffer=Buffer shed
 
-py-construction-robot-01=Construction pynobot MK 1
-py-recharge-station-mk01=Recharging station MK 1
-py-logistic-robot-01=Cargo pynobot MK 1
-py-roboport-mk01=Py roboport MK 1
+py-construction-robot-01=Construction pynobot MK 01
+py-recharge-station-mk01=Recharging station MK 01
+py-logistic-robot-01=Cargo pynobot MK 01
+py-roboport-mk01=Py roboport MK 01
 
 [entity-description]
 py-tank-1000=Sometimes you don't want to store that much.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -36,8 +36,8 @@ poorman-wood-fence=Poor man's wooden fence
 wood-fence=Wooden fence
 concrete-wall=Concrete wall
 
-accumulator-mk01=Nexelit-powered accumulator Mk I
-accumulator-mk02=Nexelit-powered accumulator Mk II
+accumulator-mk01=Nexelit-powered accumulator MK 1
+accumulator-mk02=Nexelit-powered accumulator MK 2
 py-local-radar=Local radar
 megadar=Megadar
 py-burner=Burner
@@ -65,10 +65,10 @@ py-shed-active-provider=Active provider shed
 py-shed-requester=Requester shed
 py-shed-buffer=Buffer shed
 
-py-construction-robot-01=Construction pynobot Mk I
-py-recharge-station-mk01=Recharging station Mk I
-py-logistic-robot-01=Cargo pynobot Mk I
-py-roboport-mk01=Py roboport Mk I
+py-construction-robot-01=Construction pynobot MK 1
+py-recharge-station-mk01=Recharging station MK 1
+py-logistic-robot-01=Cargo pynobot MK 1
+py-roboport-mk01=Py roboport MK 1
 
 [entity-description]
 py-tank-1000=Sometimes you don't want to store that much.

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -12,8 +12,8 @@ py-aluminium=Aluminium tile
 py-nexelit=Nexelit tile
 
 [item-description]
-py-asphalt=Good for boots
-py-coal-tile=Dark and mysterious
+py-asphalt=Good for boots.
+py-coal-tile=Dark and mysterious...
 
 [entity-name]
 py-tank-1000=PyTank (1 kL)
@@ -93,26 +93,26 @@ py-burner=Final destination of whatever you no longer need. You can collect the 
 py-sinkhole=You found a huge underground cave. Why not dump your unwanted liquids there?
 py-gas-vent=Dispose unwanted gases into the atmosphere.
 
-py-warehouse-basic=Stores many many items
-py-warehouse-passive-provider=Passive provider warehouse
-py-warehouse-storage=Storage warehouse
-py-warehouse-active-provider=Active provider warehouse
-py-warehouse-requester=Requester warehouse
-py-warehouse-buffer=Buffer warehouse
+py-warehouse-basic=Stores many, many items.
+py-warehouse-passive-provider=Passive provider warehouse.
+py-warehouse-storage=Storage warehouse.
+py-warehouse-active-provider=Active provider warehouse.
+py-warehouse-requester=Requester warehouse.
+py-warehouse-buffer=Buffer warehouse.
 
-py-storehouse-basic=Stores some items
-py-storehouse-passive-provider=Passive provider storehouse
-py-storehouse-storage=Storage storehouse
-py-storehouse-active-provider=Active provider storehouse
-py-storehouse-requester=Requester storehouse
-py-storehouse-buffer=Buffer storehouse
+py-storehouse-basic=Stores some items.
+py-storehouse-passive-provider=Passive provider storehouse.
+py-storehouse-storage=Storage storehouse.
+py-storehouse-active-provider=Active provider storehouse.
+py-storehouse-requester=Requester storehouse.
+py-storehouse-buffer=Buffer storehouse.
 
-py-shed-basic=Stores some items
-py-shed-passive-provider=Passive provider shed
-py-shed-storage=Storage shed
-py-shed-active-provider=Active provider shed
-py-shed-requester=Requester shed
-py-shed-buffer=Buffer shed
+py-shed-basic=Stores some items.
+py-shed-passive-provider=Passive provider shed.
+py-shed-storage=Storage shed.
+py-shed-active-provider=Active provider shed.
+py-shed-requester=Requester shed.
+py-shed-buffer=Buffer shed.
 
 [technology-name]
 py-storage-tanks=Storage tanks
@@ -137,7 +137,7 @@ py-aluminium=Aluminium tile
 py-nexelit=Nexelit tile
 
 [wall-name]
-poorman-wood-fence=Poor's man wood fence
+poorman-wood-fence=Poor man's wooden fence
 
 [mod-setting-name]
 py-tank-adjust=Adjust Pymods' storage tanks capacity


### PR DESCRIPTION
Full review of the English locale file:

- File renamed to be consistent with other pymods' locale files
- Spelling/grammar corrections
- Various changes to match the other py mod formatting schemes
- Capitalisation to be consistent with factorio's base capitalisation patterns
- Missing locale keys added/adjusted
- Some missing descriptions added
- Arbitrary numbering schemes reduced where possible (research tiers and ore processing intermediate numbering changed to 'stages', alien samples given 'tiers' etc.)
- Combustion mixture recipes cleaned up
