### PR TITLE
Increase driving speed on Nexelit plate tiles

### DIFF
--- a/prototypes/tiles/py-nexelit.lua
+++ b/prototypes/tiles/py-nexelit.lua
@@ -85,5 +85,5 @@ ENTITY {
     },
     map_color = defines.color.black,
     pollution_absorption_per_second = 0,
-    vehicle_friction_modifier = _G.stone_path_vehicle_speed_modifier
+    vehicle_friction_modifier = 0.33
 }


### PR DESCRIPTION
Change driving speed on Nexelit plate - faster acceleration, seems to top out about 160 km/h. Otherwise it is faster to walk than drive on the tile.