### PR TITLE
Small fixes to EN locale. In particular, fixed PyTank display sizes

### DIFF
--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -16,20 +16,20 @@ py-asphalt=Good for boots.
 py-coal-tile=Dark and mysterious...
 
 [entity-name]
-py-tank-1000=PyTank (1 kL)
-py-tank-1500=PyTank (1.5 kL)
-py-tank-3000=PyTank (3 kL)
-py-tank-4000=PyTank (4 kL)
-py-tank-5000=PyTank (5 kL)
-py-tank-6500=PyTank (6.5 kL)
-py-tank-7000=PyTank (7 kL)
-py-tank-8000=PyTank (8 kL)
+py-tank-1000=PyTank (10 kL)
+py-tank-1500=PyTank (15 kL)
+py-tank-3000=PyTank (30 kL)
+py-tank-4000=PyTank (40 kL)
+py-tank-5000=PyTank (50 kL)
+py-tank-6500=PyTank (65 kL)
+py-tank-7000=PyTank (70 kL)
+py-tank-8000=PyTank (80 kL)
 
-py-tank-3000-adjust=PyTank (1 kL)
-py-tank-4000-adjust=PyTank (2.75 kL)
-py-tank-5000-adjust=PyTank (6.5 kL)
-py-tank-6500-adjust=PyTank (7.5 kL)
-py-tank-8000-adjust=PyTank (12.5 kL)
+py-tank-3000-adjust=PyTank (10 kL)
+py-tank-4000-adjust=PyTank (27.5 kL)
+py-tank-5000-adjust=PyTank (65 kL)
+py-tank-6500-adjust=PyTank (75 kL)
+py-tank-8000-adjust=PyTank (125 kL)
 
 py-check-valve=Check valve
 py-overflow-valve=Overflow valve
@@ -72,11 +72,11 @@ py-shed-requester=Requester shed
 py-shed-buffer=Buffer shed
 
 py-deposit-basic=Deposit
-py-deposit-passive-provider=Passive provider Deposit
-py-deposit-storage=Storage Deposit
-py-deposit-active-provider=Active provider Deposit
-py-deposit-requester=Requester Deposit
-py-deposit-buffer=Buffer Deposit
+py-deposit-passive-provider=Passive provider deposit
+py-deposit-storage=Storage deposit
+py-deposit-active-provider=Active provider deposit
+py-deposit-requester=Requester deposit
+py-deposit-buffer=Buffer deposit
 
 py-construction-robot-01=Construction pynobot MK 01
 py-recharge-station-mk01=Recharging station MK 01
@@ -86,8 +86,8 @@ py-roboport-mk02=Py roboport MK 02
 barrel-machine-mk01=Barreling Machine
 
 mk02-locomotive=Advanced locomotive
-mk02-wagon=Advanced Cargo Wagon
-mk02-fluid-wagon=Advanced Fluid Wagon
+mk02-wagon=Advanced cargo wagon
+mk02-fluid-wagon=Advanced fluid wagon
 
 [entity-description]
 py-tank-1000=Sometimes you don't want to store that much.


### PR DESCRIPTION
This is maybe a controversial one, as I align the PyTank sizes to their actual sizes. Let me know if this is not desired, then I can make a pull request with only the other localisation corrections.