### PR TITLE
Redefined Asphalt and Coal tile entities

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 2.0.11
 Date: When it's done
   Changes:
     - Improved circuit connector placement for 30kL tank (credit: JStMorgan)
+    - Fixed Asphalt and Coal tiles replacing dark vanilla Lab tiles (https://github.com/pyanodon/pybugreports/issues/321) (credit: JStMorgan)
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.10
 Date: 2023-9-4

--- a/prototypes/tiles/py-asphalt.lua
+++ b/prototypes/tiles/py-asphalt.lua
@@ -25,20 +25,45 @@ ITEM {
     order = 'zb',
     stack_size = 1000,
     default_request_amount = 150,
-    place_as_tile = {result = 'lab-dark-2', condition_size = 1, condition = {'water-tile'}}
+    place_as_tile = {result = 'py-asphalt', condition_size = 1, condition = {'water-tile'}}
 }
 
-data.raw.tile['lab-dark-2'].minable = {mining_time = 0.1, result = 'py-asphalt'}
-data.raw.tile['lab-dark-2'].mined_sound = {filename = '__base__/sound/deconstruct-bricks.ogg'}
-data.raw.tile['lab-dark-2'].walking_speed_modifier = 3.25
-data.raw.tile['lab-dark-2'].decorative_removal_probability = 1
-data.raw.tile['lab-dark-2'].layer = 100
-data.raw.tile['lab-dark-2'].walking_sound = table.deepcopy(data.raw.tile['grass-1'].walking_sound)
-data.raw.tile['lab-dark-2'].collision_mask = {'ground-tile'}
-data.raw.tile['lab-dark-2'].vehicle_friction_modifier = 0.6
-data.raw.tile['lab-dark-2'].tint = {0.4,0.4,0.4}
-
-local old = data.raw.tile['lab-dark-2'].variants.main
-add_material_background(data.raw.tile['lab-dark-2'])
-data.raw.tile['lab-dark-2'].variants.material_background = nil
-data.raw.tile['lab-dark-2'].variants.main = old
+ENTITY {
+    type = "tile",
+    name = "py-asphalt",
+    needs_correction = false,
+    minable = {mining_time = 0.1, result = "py-asphalt"},
+    mined_sound = {filename = "__base__/sound/deconstruct-bricks.ogg"},
+    collision_mask = {"ground-tile"},
+    walking_speed_modifier = 3.25,
+    decorative_removal_probability = 1,
+    layer = 100,
+    variants = {
+        main = data.raw.tile['lab-dark-2'].variants.main ,
+        inner_corner = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-inner-corner.png",
+            count = 8
+        },
+        outer_corner = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-outer-corner.png",
+            count = 8
+        },
+        side = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-side.png",
+            count = 8
+        },
+        u_transition = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-u.png",
+            count = 8
+        },
+        o_transition = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-o.png",
+            count = 1
+        }
+    },
+    walking_sound = table.deepcopy(data.raw.tile['grass-1'].walking_sound),
+    map_color = {r = 0, g = 0, b = 0, a = 1},
+    pollution_absorption_per_second = 0,
+    vehicle_friction_modifier = 0.6,
+    tint = {0.4,0.4,0.4}
+}

--- a/prototypes/tiles/py-coal-tile.lua
+++ b/prototypes/tiles/py-coal-tile.lua
@@ -29,20 +29,45 @@ ITEM {
     subgroup = 'py-tiles',
     order = 'za',
     stack_size = 1000,
-    place_as_tile = {result = 'lab-dark-1', condition_size = 1, condition = {'water-tile'}}
+    place_as_tile = {result = 'py-coal-tile', condition_size = 1, condition = {'water-tile'}}
 }
 
-data.raw.tile['lab-dark-1'].minable = {mining_time = 0.1, result = 'py-coal-tile'}
-data.raw.tile['lab-dark-1'].mined_sound = {filename = '__base__/sound/deconstruct-bricks.ogg'}
-data.raw.tile['lab-dark-1'].walking_speed_modifier = 3.25
-data.raw.tile['lab-dark-1'].decorative_removal_probability = 1
-data.raw.tile['lab-dark-1'].layer = 101
-data.raw.tile['lab-dark-1'].walking_sound = table.deepcopy(data.raw.tile['grass-1'].walking_sound)
-data.raw.tile['lab-dark-1'].collision_mask = {'ground-tile'}
-data.raw.tile['lab-dark-1'].vehicle_friction_modifier = 0.6
-data.raw.tile['lab-dark-1'].tint = {0.2,0.2,0.2}
-
-local old = data.raw.tile['lab-dark-1'].variants.main
-add_material_background(data.raw.tile['lab-dark-1'])
-data.raw.tile['lab-dark-1'].variants.material_background = nil
-data.raw.tile['lab-dark-1'].variants.main = old
+ENTITY {
+    type = "tile",
+    name = "py-coal-tile",
+    needs_correction = false,
+    minable = {mining_time = 0.1, result = "py-coal-tile"},
+    mined_sound = {filename = "__base__/sound/deconstruct-bricks.ogg"},
+    collision_mask = {"ground-tile"},
+    walking_speed_modifier = 3.25,
+    decorative_removal_probability = 1,
+    layer = 101,
+    variants = {
+        main = data.raw.tile['lab-dark-1'].variants.main,
+        inner_corner = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-inner-corner.png",
+            count = 8
+        },
+        outer_corner = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-outer-corner.png",
+            count = 8
+        },
+        side = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-side.png",
+            count = 8
+        },
+        u_transition = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-u.png",
+            count = 8
+        },
+        o_transition = {
+            picture = "__pyindustry__/graphics/tiles/py-asphalt/concrete-o.png",
+            count = 1
+        }
+    },
+    walking_sound = table.deepcopy(data.raw.tile['grass-1'].walking_sound),
+    map_color = {r = 50, g = 50, b = 50, a = 1},
+    pollution_absorption_per_second = 0,
+    vehicle_friction_modifier = 0.6,
+    tint = {0.2,0.2,0.2}
+}


### PR DESCRIPTION
Addresses pyanodon/pybugreports#321 .

This PR moves Asphalt and Coal tiles back to their own stand-alone entity definitions, meaning they can co-exist with the dark set of lab tiles used in sandbox/dev environments. Their appearance has changed somewhat as well, so any further input here is appreciated ⚙️ 

![20230927173042_1](https://github.com/pyanodon/pyindustry/assets/47102583/d77f758d-c10d-4f02-8b66-7f36b740205c)
