### PR TITLE
Fixed Coal and Asphalt tile names

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 2.0.11
 Date: When it's done
   Changes:
+    - Adjusted stack size of vanilla paving from 100 to 1000
     - Improved circuit connector placement for 30kL tank (credit: JStMorgan)
     - Fixed Asphalt and Coal tiles replacing dark vanilla Lab tiles (https://github.com/pyanodon/pybugreports/issues/321) (credit: JStMorgan)
     - added decentralised PyPP cache file

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -220,7 +220,7 @@ py-tank-adjust=Makes tank capacity consistent with their physical size
 py-void=Void __1__
 
 [equipment-name]
-portable-gasolene-generator=Portable gasoline generator
+portable-gasolene-generator=Portable gasolene generator
 fusion-reactor-equipment=Portable fusion reaction housing
 
 [equipment-description]

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -197,8 +197,8 @@ railway-mk03=Unlock high-tech nexelit trains with a huge acceleration.
 railway-mk04=Unlock quantum energy hypersonic space trains.
 
 [tile-name]
-lab-dark-2=Asphalt
-lab-dark-1=Coal tile
+py-asphalt=Asphalt
+py-coal-tile=Coal tile
 lab-white=Purified quartz tile
 py-limestone=Limestone tile
 py-iron-oxide=Iron oxide tile
@@ -220,7 +220,7 @@ py-tank-adjust=Makes tank capacity consistent with their physical size
 py-void=Void __1__
 
 [equipment-name]
-portable-gasolene-generator=Portable gasolene generator
+portable-gasolene-generator=Portable gasoline generator
 fusion-reactor-equipment=Portable fusion reaction housing
 
 [equipment-description]

--- a/migrations/2.0.11.json
+++ b/migrations/2.0.11.json
@@ -1,0 +1,6 @@
+{
+    "tile": [
+        ["lab-dark-1", "py-coal-tile"],
+        ["lab-dark-2", "py-asphalt"]
+    ]
+}


### PR DESCRIPTION
This PR fixes a locale issue I left behind in #90 , and also adds the change to vanilla paving tiles to the changelog.