### PR TITLE
Fix braided pipe support when other mods add pipes

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -78,9 +78,11 @@ if settings.startup["py-braided-pipes"].value then
         ::continue::
     end
 
-    for _, pipe in pairs {data.raw.pipe.pipe, data.raw["pipe-to-ground"]["pipe-to-ground"]} do
+    for _, pipe in pairs {table.unpack(data.raw["pipe"]), table.unpack(data.raw["pipe-to-ground"])} do
         for _, pipe_connection in pairs(pipe.fluid_box.pipe_connections) do
-            pipe_connection.connection_category = {"pipe"}
+            if pipe_connection.connection_category == nil then
+                pipe_connection.connection_category = {"pipe"}
+            end
         end
     end
 end


### PR DESCRIPTION
Previously, when braided pipes was enabled, any third-party pipes that did not specify a connection category would misbehave. In particular, the color-coded pipes mod fell over spectacularly if colored and uncolored pipes were ever allowed to mix.

This changes pyindustry to assign its default connection category to all `pipe` and `pipe-to-ground` instances when they have not set their own connection category. This causes all such pipes to behave simply as normal pipes W.R.T. the overall connection scheme.

This is kind of a sledgehammer, but it is also the absolute fallback, given where it ends up being called. For specific mods other connection plans might make sense, but as long as their connection category is set before `data-final-fixes`, this code will ignore them and leave them as-is.