### PR TITLE
Fix circuit connector for exhaust vent (py-gas-vent)

### DIFF
--- a/prototypes/buildings/gas-vent.lua
+++ b/prototypes/buildings/gas-vent.lua
@@ -104,6 +104,7 @@ ENTITY {
         },
     },
     fast_replaceable_group = "py-gas-vent",
+    circuit_wire_max_distance = 9,
     circuit_connector = circuit_connector_definitions.create_vector(
         universal_connector_template,
         {


### PR DESCRIPTION
This is a bug-report and fix combined.

After https://github.com/pyanodon/pyindustry/commit/cf357ea63c6dd728d9e2c0a0d3b4d571c3ad32c9 I was no longer able to connect logical wires to the exhaust vent:

![image](https://github.com/user-attachments/assets/84c6061f-f246-4330-a058-633eb5f4f37c)

It appears to be because no `circuit_wire_max_distance` is defined, and adding default value of 9 fixes the issue. I'm running pyanadon of latest version with this fix applied and able to connect circuit wire to the exhaust vent:
![image](https://github.com/user-attachments/assets/f970c964-dd99-4e6d-850f-0df409f853b2)

