### PR TITLE
Tailings & Muddy Water Internal Name Change

### DIFF
--- a/prototypes/tiles/py-iron-oxide.lua
+++ b/prototypes/tiles/py-iron-oxide.lua
@@ -6,7 +6,7 @@ RECIPE {
     ingredients = {
         {type = "item",  name = "iron-oxide",        amount = 4},
         {type = "item",  name = "pipe",              amount = 1},
-        {type = "fluid", name = "dirty-water-light", amount = 20}
+        {type = "fluid", name = "muddy-sludge", amount = 20}
     },
     results = {
         {type = "item", name = "py-iron-oxide", amount = 2}


### PR DESCRIPTION
## What?

    - Changed internal name of "dirty-water-light" to "tailings".
    - Changed internal name of "dirty-water-heavy" to "muddy-water".
    
## Why?

    - This has always annoyed me.
    - Fixes https://github.com/pyanodon/pybugreports/issues/1076
    
Changelog & migration are present in pycoalprocessing.
All similarly named PRs must be merged at the same time!